### PR TITLE
fix on find or create text channel 

### DIFF
--- a/BuffBot/global_methods.py
+++ b/BuffBot/global_methods.py
@@ -37,8 +37,8 @@ async def say_tax(ctx, msg, bot):
 async def find_or_create_text_channel(name, server, bot) :
 
     channels = server.channels
-    for channel in channels :
-        if channel.type == 'text' and channel.name == name :
+    for channel in channels  :
+        if str(channel.type) == 'text' and channel.name == name :
             return channel
     return await bot.create_channel(name=name, server=server, type='text')
 


### PR DESCRIPTION
Fixed a issue that it did not recognize channel name and therefor made duplicate channels. 